### PR TITLE
Fix gravmag env

### DIFF
--- a/courses/gravmag/environment_gravmag.yml
+++ b/courses/gravmag/environment_gravmag.yml
@@ -2,13 +2,13 @@ name: gravmag
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - basemap
   - pyshtools
   - boule
   - cartopy
   - cartopy_offlinedata
-  - gmt=6.0.0
+  - gmt
   - harmonica
   - ipykernel
   - matplotlib
@@ -17,15 +17,15 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pip
+  - pip<20
   - pyproj
   - scikit-learn
   - scipy
-  - sphinx<3
-  - sphinx_rtd_theme<0.4.3
+  - sphinx
+  - sphinx_rtd_theme
   - simplekml
   - utm
   - xarray
   - pip:
     - geophpy==0.31
-    - git+https://github.com/GenericMappingTools/pygmt.git@dc178ed6d045275bf642023fe544d73154d5c987
+    - git+https://github.com/GenericMappingTools/pygmt.git@v0.3.1


### PR DESCRIPTION
This fixes #9.

The underlying reason for the hassle is `geophpy` which has a very strange way of setting up things. I don't find any git repo or issue tracker. @nholzrichter Do you know if we can contact anyone working on `geophpy`? I think in the near future, we won't be able to resolve environments containing it.